### PR TITLE
!refactor(element): rename elements to match html

### DIFF
--- a/pkgs/nitori_message/example/nitori_message_example.dart
+++ b/pkgs/nitori_message/example/nitori_message_example.dart
@@ -5,8 +5,8 @@ void main() {
     n.At(id: '001', name: 'Kawashiro Nitori'),
     n.Text('Hello, world!'),
     n.Image(src: 'https://example.com/image.png'),
-    n.Br(),
-    n.Strong('Welcome to Nitori: '),
+    n.LineBreak(),
+    n.Bold('Welcome to Nitori: '),
     n.Sharp(id: '001', name: 'Kawashiro Channel'),
   ]);
   print(message);

--- a/pkgs/nitori_message/lib/src/elements.dart
+++ b/pkgs/nitori_message/lib/src/elements.dart
@@ -34,10 +34,10 @@ class Sharp extends Base {
         });
 }
 
-class A extends Base {
+class Anchor extends Base {
   String href;
 
-  A({
+  Anchor({
     required this.href,
   }) : super('a', attributes: {
           'href': href,
@@ -48,12 +48,12 @@ class A extends Base {
 
 // #region Layout
 
-class Br extends Base {
-  Br() : super('br');
+class LineBreak extends Base {
+  LineBreak() : super('br');
 }
 
-class P extends Base {
-  P({attributes, children})
+class Paragraph extends Base {
+  Paragraph({attributes, children})
       : super('p', attributes: attributes, children: children);
 }
 
@@ -94,48 +94,48 @@ class Author extends Base {
 
 // #region Modifier
 
-class Strong extends Base {
-  Strong(String text) : super('strong', children: [Text(text)]);
+class Bold extends Base {
+  Bold(String text) : super('b', children: [Text(text)]);
 }
 
-class Em extends Base {
-  Em(String text) : super('em', children: [Text(text)]);
+class Idiomatic extends Base {
+  Idiomatic(String text) : super('i', children: [Text(text)]);
 }
 
-class Ins extends Base {
-  Ins(String text) : super('ins', children: [Text(text)]);
+class Underline extends Base {
+  Underline(String text) : super('u', children: [Text(text)]);
 }
 
-class Del extends Base {
-  Del(String text) : super('del', children: [Text(text)]);
+class Strikethrough extends Base {
+  Strikethrough(String text) : super('s', children: [Text(text)]);
 }
 
-class Spl extends Base {
-  Spl(String text) : super('spl', children: [Text(text)]);
+class Spoiler extends Base {
+  Spoiler(String text) : super('spl', children: [Text(text)]);
 }
 
 class Code extends Base {
   Code(String text) : super('code', children: [Text(text)]);
 }
 
-class Sup extends Base {
-  Sup(String text) : super('sup', children: [Text(text)]);
+class Superscript extends Base {
+  Superscript(String text) : super('sup', children: [Text(text)]);
 }
 
-class Sub extends Base {
-  Sub(String text) : super('sub', children: [Text(text)]);
+class Subscript extends Base {
+  Subscript(String text) : super('sub', children: [Text(text)]);
 }
 
 // #endregion
 
 // #region Resource
 
-class ResourceElement extends Base {
+class _ResourceElement extends Base {
   String src;
   bool? cache;
   String? timeout;
 
-  ResourceElement({
+  _ResourceElement({
     required String tag,
     required this.src,
     this.cache,
@@ -149,11 +149,11 @@ class ResourceElement extends Base {
             }..addAll(attributes ?? {}));
 }
 
-class Img extends ResourceElement {
+class Image extends _ResourceElement {
   int? width;
   int? height;
 
-  Img({
+  Image({
     required String src,
     this.width,
     this.height,
@@ -171,9 +171,7 @@ class Img extends ResourceElement {
         );
 }
 
-typedef Image = Img;
-
-class Audio extends ResourceElement {
+class Audio extends _ResourceElement {
   Audio({
     required String src,
     bool? cache,
@@ -186,7 +184,7 @@ class Audio extends ResourceElement {
         );
 }
 
-class Video extends ResourceElement {
+class Video extends _ResourceElement {
   Video({
     required String src,
     bool? cache,
@@ -199,7 +197,7 @@ class Video extends ResourceElement {
         );
 }
 
-class File extends ResourceElement {
+class File extends _ResourceElement {
   File({
     required String src,
     bool? cache,

--- a/pkgs/nitori_message/lib/src/parser.dart
+++ b/pkgs/nitori_message/lib/src/parser.dart
@@ -13,9 +13,9 @@ Node? _createTag(String tag, dynamic attributes, dynamic children) {
     case 'sharp':
       return Sharp(id: attributes['id'], name: attributes['name']);
     case 'a':
-      return A(href: attributes['href']);
+      return Anchor(href: attributes['href']);
     case 'img':
-      return Img(
+      return Image(
           src: attributes['src'],
           cache: attributes['cache'],
           timeout: attributes['timeout'],
@@ -38,30 +38,30 @@ Node? _createTag(String tag, dynamic attributes, dynamic children) {
           timeout: attributes['timeout']);
     case 'b':
     case 'strong':
-      return Strong((children as List<Node>)
+      return Bold((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 'i':
     case 'em':
-      return Em((children as List<Node>)
+      return Idiomatic((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 'u':
     case 'ins':
-      return Ins((children as List<Node>)
+      return Underline((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 's':
     case 'del':
-      return Del((children as List<Node>)
+      return Strikethrough((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 'spl':
-      return Spl((children as List<Node>)
+      return Spoiler((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
@@ -71,19 +71,19 @@ Node? _createTag(String tag, dynamic attributes, dynamic children) {
           .map((e) => e.text)
           .join(''));
     case 'sup':
-      return Sup((children as List<Node>)
+      return Superscript((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 'sub':
-      return Sub((children as List<Node>)
+      return Subscript((children as List<Node>)
           .whereType<Text>()
           .map((e) => e.text)
           .join(''));
     case 'br':
-      return Br();
+      return LineBreak();
     case 'p':
-      return P(attributes: attributes, children: children);
+      return Paragraph(attributes: attributes, children: children);
     case 'message':
       return Message(
           id: attributes['id'],

--- a/pkgs/nitori_message/test/elements_test.dart
+++ b/pkgs/nitori_message/test/elements_test.dart
@@ -73,10 +73,10 @@ void main() {
     });
 
     test('Modifier', () {
-      expect(n.Bold('test').toString(), equals('<strong>test</strong>'));
-      expect(n.Idiomatic('test').toString(), equals('<em>test</em>'));
-      expect(n.Underline('test').toString(), equals('<ins>test</ins>'));
-      expect(n.Strikethrough('test').toString(), equals('<del>test</del>'));
+      expect(n.Bold('test').toString(), equals('<b>test</b>'));
+      expect(n.Idiomatic('test').toString(), equals('<i>test</i>'));
+      expect(n.Underline('test').toString(), equals('<u>test</u>'));
+      expect(n.Strikethrough('test').toString(), equals('<s>test</s>'));
       expect(n.Spoiler('test').toString(), equals('<spl>test</spl>'));
       expect(n.Code('test').toString(), equals('<code>test</code>'));
       expect(n.Superscript('test').toString(), equals('<sup>test</sup>'));

--- a/pkgs/nitori_message/test/elements_test.dart
+++ b/pkgs/nitori_message/test/elements_test.dart
@@ -15,19 +15,21 @@ void main() {
       expect(n.Sharp(id: '1', name: 'test').toString(),
           equals('<sharp id="1" name="test"/>'));
       // A Element
-      expect(n.A(href: 'https://example.com').toString(),
+      expect(n.Anchor(href: 'https://example.com').toString(),
           equals('<a href="https://example.com"/>'));
     });
 
     test('Layout', () {
       // Br Element
-      expect(n.Br().toString(), equals('<br/>'));
+      expect(n.LineBreak().toString(), equals('<br/>'));
       // P Element
-      expect(n.P().toString(), equals('<p/>'));
-      expect(n.P(children: [n.Text('test')]).toString(), equals('<p>test</p>'));
-      expect(n.P(children: [n.Text('test'), n.Text('test2')]).toString(),
+      expect(n.Paragraph().toString(), equals('<p/>'));
+      expect(n.Paragraph(children: [n.Text('test')]).toString(),
+          equals('<p>test</p>'));
+      expect(
+          n.Paragraph(children: [n.Text('test'), n.Text('test2')]).toString(),
           equals('<p>testtest2</p>'));
-      expect(n.P(children: [n.Text('test'), n.Br()]).toString(),
+      expect(n.Paragraph(children: [n.Text('test'), n.LineBreak()]).toString(),
           equals('<p>test<br/></p>'));
       // Message Element
       expect(n.Message().toString(), equals('<message/>'));
@@ -61,7 +63,8 @@ void main() {
               .toString(),
           equals('<img src="https://example.com" cache timeout="1000"/>'));
       expect(
-          n.Img(src: 'https://example.com', width: 300, height: 200).toString(),
+          n.Image(src: 'https://example.com', width: 300, height: 200)
+              .toString(),
           equals('<img src="https://example.com" width="300" height="200"/>'));
       expect(n.Audio(src: 'https://example.com').toString(),
           equals('<audio src="https://example.com"/>'));
@@ -70,14 +73,14 @@ void main() {
     });
 
     test('Modifier', () {
-      expect(n.Strong('test').toString(), equals('<strong>test</strong>'));
-      expect(n.Em('test').toString(), equals('<em>test</em>'));
-      expect(n.Ins('test').toString(), equals('<ins>test</ins>'));
-      expect(n.Del('test').toString(), equals('<del>test</del>'));
-      expect(n.Spl('test').toString(), equals('<spl>test</spl>'));
+      expect(n.Bold('test').toString(), equals('<strong>test</strong>'));
+      expect(n.Idiomatic('test').toString(), equals('<em>test</em>'));
+      expect(n.Underline('test').toString(), equals('<ins>test</ins>'));
+      expect(n.Strikethrough('test').toString(), equals('<del>test</del>'));
+      expect(n.Spoiler('test').toString(), equals('<spl>test</spl>'));
       expect(n.Code('test').toString(), equals('<code>test</code>'));
-      expect(n.Sup('test').toString(), equals('<sup>test</sup>'));
-      expect(n.Sub('test').toString(), equals('<sub>test</sub>'));
+      expect(n.Superscript('test').toString(), equals('<sup>test</sup>'));
+      expect(n.Subscript('test').toString(), equals('<sub>test</sub>'));
     });
   });
 }

--- a/pkgs/nitori_message/test/parser_test.dart
+++ b/pkgs/nitori_message/test/parser_test.dart
@@ -47,26 +47,26 @@ void main() {
       expect(n.parse('<sharp id="1" name="test"/>'),
           equals([n.Sharp(id: '1', name: 'test')]));
       expect(n.parse('<a href="https://example.com"/>'),
-          equals([n.A(href: 'https://example.com')]));
+          equals([n.Anchor(href: 'https://example.com')]));
     });
 
     test('Layout', () {
-      expect(n.parse('<br/>'), equals([n.Br()]));
-      expect(n.parse('<p/>'), equals([n.P()]));
+      expect(n.parse('<br/>'), equals([n.LineBreak()]));
+      expect(n.parse('<p/>'), equals([n.Paragraph()]));
       expect(
           n.parse('<p>test</p>'),
           equals([
-            n.P(children: [n.Text('test')])
+            n.Paragraph(children: [n.Text('test')])
           ]));
       expect(
           n.parse('<p>testtest2</p>'),
           equals([
-            n.P(children: [n.Text('testtest2')])
+            n.Paragraph(children: [n.Text('testtest2')])
           ]));
       expect(
           n.parse('<p>test<br/></p>'),
           equals([
-            n.P(children: [n.Text('test'), n.Br()])
+            n.Paragraph(children: [n.Text('test'), n.LineBreak()])
           ]));
       expect(n.parse('<message/>'), equals([n.Message()]));
       expect(n.parse('<message id="1"/>'), equals([n.Message(id: '1')]));
@@ -108,7 +108,8 @@ void main() {
           ]));
       expect(
           n.parse('<img src="https://example.com" width="300" height="200"/>'),
-          equals([n.Img(src: 'https://example.com', width: 300, height: 200)]));
+          equals(
+              [n.Image(src: 'https://example.com', width: 300, height: 200)]));
       expect(n.parse('<audio src="https://example.com"/>'),
           equals([n.Audio(src: 'https://example.com')]));
       expect(n.parse('<video src="https://example.com"/>'),
@@ -116,18 +117,18 @@ void main() {
     });
 
     test('Modifier', () {
-      expect(n.parse('<strong>test</strong>'), equals([n.Strong('test')]));
-      expect(n.parse('<b>test</b>'), equals([n.Strong('test')]));
-      expect(n.parse('<em>test</em>'), equals([n.Em('test')]));
-      expect(n.parse('<i>test</i>'), equals([n.Em('test')]));
-      expect(n.parse('<ins>test</ins>'), equals([n.Ins('test')]));
-      expect(n.parse('<u>test</u>'), equals([n.Ins('test')]));
-      expect(n.parse('<del>test</del>'), equals([n.Del('test')]));
-      expect(n.parse('<s>test</s>'), equals([n.Del('test')]));
-      expect(n.parse('<spl>test</spl>'), equals([n.Spl('test')]));
+      expect(n.parse('<strong>test</strong>'), equals([n.Bold('test')]));
+      expect(n.parse('<b>test</b>'), equals([n.Bold('test')]));
+      expect(n.parse('<em>test</em>'), equals([n.Idiomatic('test')]));
+      expect(n.parse('<i>test</i>'), equals([n.Idiomatic('test')]));
+      expect(n.parse('<ins>test</ins>'), equals([n.Underline('test')]));
+      expect(n.parse('<u>test</u>'), equals([n.Underline('test')]));
+      expect(n.parse('<del>test</del>'), equals([n.Strikethrough('test')]));
+      expect(n.parse('<s>test</s>'), equals([n.Strikethrough('test')]));
+      expect(n.parse('<spl>test</spl>'), equals([n.Spoiler('test')]));
       expect(n.parse('<code>test</code>'), equals([n.Code('test')]));
-      expect(n.parse('<sup>test</sup>'), equals([n.Sup('test')]));
-      expect(n.parse('<sub>test</sub>'), equals([n.Sub('test')]));
+      expect(n.parse('<sup>test</sup>'), equals([n.Superscript('test')]));
+      expect(n.parse('<sub>test</sub>'), equals([n.Subscript('test')]));
     });
   });
 }


### PR DESCRIPTION
This commit contains BREAKING CHANGE:

- exports from `nitori_element` was renamed:
  - `A` -> `Anchor`
  - `Br` -> `LineBreak`
  - `Strong` -> `Bold`
  - `Em` -> `Idiomatic`
  - `ins` -> `Underline`
  - `Del` -> `Strikethrough`
  - `Spl` -> `Spoiler`
  - `Sup` -> `Superscript`
  - `Sub` -> `Subscript`
  - `Img` -> `Image`
- `ResourceElement` won't be exposed