### PR TITLE
fix: should strip white spaces except `<code>`

### DIFF
--- a/pkgs/nitori_message/test/parser_test.dart
+++ b/pkgs/nitori_message/test/parser_test.dart
@@ -131,4 +131,62 @@ void main() {
       expect(n.parse('<sub>test</sub>'), equals([n.Subscript('test')]));
     });
   });
+
+  group('Examples', () {
+    test('Single Message', () {
+      expect(
+          n.parse("""<message>
+  <at id="1" name="test"/>
+  <at id="2" name="test2"/>
+  <br/>
+  <p>test</p>
+  <img src="https://example.com"/>
+  <audio src="https://example.com"/>
+  <p>
+    <b>bold</b><sup>sup</sup><sub>sub</sub>
+    <spl>spoiler</spl>
+    <code>code</code>
+    <u>underline</u>
+    <s>strikethrough</s>
+  </p>
+</message>"""),
+          equals([
+            n.Message(
+              children: [
+                n.At(id: '1', name: 'test'),
+                n.At(id: '2', name: 'test2'),
+                n.LineBreak(),
+                n.Paragraph(children: [n.Text('test')]),
+                n.Image(src: 'https://example.com'),
+                n.Audio(src: 'https://example.com'),
+                n.Paragraph(children: [
+                  n.Bold('bold'),
+                  n.Superscript('sup'),
+                  n.Subscript('sub'),
+                  n.Spoiler('spoiler'),
+                  n.Code('code'),
+                  n.Underline('underline'),
+                  n.Strikethrough('strikethrough')
+                ])
+              ],
+            )
+          ]));
+
+      expect(
+          n.parse("""<message>
+<code>
+  yarn add nitori
+  yarn run test
+  npm publish
+</code>
+</message>"""),
+          equals([
+            n.Message(
+              children: [
+                n.Code('  yarn add nitori\n  yarn run test\n  npm publish')
+              ],
+            )
+          ]));
+    });
+  });
 }


### PR DESCRIPTION
According to HTML spec, when you have white spaces between elements, they should be stripped:

```html
<message>
  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
  <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
</message>
```

would produce:

```dart
Message(children: [
  Paragraph(children: [Text('Lorem ipsum ...')]),
  Paragraph(children: [Text('Ut enim ad ...')]),
]);
```

But not in `<code>`:

```html
<code>
  cp foo bar
  rm -rf /*
</code>
```

would produce:

```dart
Code(children: [
  Text('  cp foo bar\n  rm -rf /*'), // the leading and trailing newlines would be stripped though.
]);
```